### PR TITLE
Update E=256,N=256,device_name=AMD_Instinct_MI300X,dtype=fp8_w8a8,blo…

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/configs/E=256,N=256,device_name=AMD_Instinct_MI300X,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/configs/E=256,N=256,device_name=AMD_Instinct_MI300X,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -72,10 +72,10 @@
         "waves_per_eu": 0
     },
     "64": {
-        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_M": 32,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 1,
+        "GROUP_SIZE_M": 4,
         "num_warps": 4,
         "num_stages": 2,
         "waves_per_eu": 0


### PR DESCRIPTION
…ck_shape=[128, 128].json

Update bs 64 config for mi300x for DeepSeekV3 perf

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Update bs 64 config for mi300x for DeepSeekV3 perf
DeepSeekV3 max concurrency 64, isl 3200, osl 800, request rate inf, the req throughput increases from 0.4 to 0.6 on mi300x

## Modifications

Update BS 64 config of sglang/python/sglang/srt/layers/moe/fused_moe_triton/configs/E\=256\,N\=256\,device_name\=AMD_Instinct_MI300X\,dtype\=fp8_w8a8\,block_shape\=\[128\,\ 128\].json

## Checklist

- [X] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [X] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
