### PR TITLE
Fix gfx95 bpreshuffle FP8 activation scale layout

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -59,6 +59,10 @@ from sglang.srt.layers.moe import (
     should_use_dp_reduce_scatterv,
     should_use_flashinfer_cutlass_moe_fp4_allgather,
 )
+from sglang.srt.layers.quantization.fp8_utils import (
+    _use_aiter_bpreshuffle_gfx95,
+    materialize_bpreshuffle_fp8_scale_tuple,
+)
 from sglang.srt.layers.utils.cp_utils import (
     is_mla_prefill_cp_enabled,
     mla_use_prefill_cp,
@@ -607,6 +611,10 @@ class LayerCommunicator:
                             output_unquantized_inp1=_dsa_needs_bf16,
                             transpose_scale=False,
                         )
+                        if _use_aiter_bpreshuffle_gfx95:
+                            hidden_states = materialize_bpreshuffle_fp8_scale_tuple(
+                                hidden_states
+                            )
                         if _dsa_needs_bf16:
                             hidden_states = (
                                 hidden_states[0],
@@ -654,6 +662,10 @@ class LayerCommunicator:
                                 transpose_scale=False,
                             )
                         )
+                        if _use_aiter_bpreshuffle_gfx95:
+                            hidden_states = materialize_bpreshuffle_fp8_scale_tuple(
+                                hidden_states
+                            )
                         if _dsa_needs_bf16:
                             hidden_states = (
                                 hidden_states[0],

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -59,10 +59,6 @@ from sglang.srt.layers.moe import (
     should_use_dp_reduce_scatterv,
     should_use_flashinfer_cutlass_moe_fp4_allgather,
 )
-from sglang.srt.layers.quantization.fp8_utils import (
-    _use_aiter_bpreshuffle_gfx95,
-    materialize_bpreshuffle_fp8_scale_tuple,
-)
 from sglang.srt.layers.utils.cp_utils import (
     is_mla_prefill_cp_enabled,
     mla_use_prefill_cp,
@@ -611,10 +607,6 @@ class LayerCommunicator:
                             output_unquantized_inp1=_dsa_needs_bf16,
                             transpose_scale=False,
                         )
-                        if _use_aiter_bpreshuffle_gfx95:
-                            hidden_states = materialize_bpreshuffle_fp8_scale_tuple(
-                                hidden_states
-                            )
                         if _dsa_needs_bf16:
                             hidden_states = (
                                 hidden_states[0],
@@ -662,10 +654,6 @@ class LayerCommunicator:
                                 transpose_scale=False,
                             )
                         )
-                        if _use_aiter_bpreshuffle_gfx95:
-                            hidden_states = materialize_bpreshuffle_fp8_scale_tuple(
-                                hidden_states
-                            )
                         if _dsa_needs_bf16:
                             hidden_states = (
                                 hidden_states[0],

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -59,7 +59,10 @@ from sglang.srt.layers.moe import (
     should_use_dp_reduce_scatterv,
     should_use_flashinfer_cutlass_moe_fp4_allgather,
 )
-from sglang.srt.layers.quantization.fp8_utils import _use_aiter_bpreshuffle_gfx95
+from sglang.srt.layers.quantization.fp8_utils import (
+    _use_aiter_bpreshuffle_gfx95,
+    materialize_bpreshuffle_fp8_scale_tuple,
+)
 from sglang.srt.layers.utils.cp_utils import (
     is_mla_prefill_cp_enabled,
     mla_use_prefill_cp,
@@ -606,8 +609,12 @@ class LayerCommunicator:
                             dtype_quant=torch.float8_e4m3fn,
                             res1=None,
                             output_unquantized_inp1=_dsa_needs_bf16,
-                            transpose_scale=_use_aiter_bpreshuffle_gfx95,
+                            transpose_scale=False,
                         )
+                        if _use_aiter_bpreshuffle_gfx95:
+                            hidden_states = materialize_bpreshuffle_fp8_scale_tuple(
+                                hidden_states
+                            )
                         if _dsa_needs_bf16:
                             hidden_states = (
                                 hidden_states[0],
@@ -652,9 +659,13 @@ class LayerCommunicator:
                                 dtype_quant=torch.float8_e4m3fn,
                                 res1=residual,
                                 output_unquantized_inp1=_dsa_needs_bf16,
-                                transpose_scale=_use_aiter_bpreshuffle_gfx95,
+                                transpose_scale=False,
                             )
                         )
+                        if _use_aiter_bpreshuffle_gfx95:
+                            hidden_states = materialize_bpreshuffle_fp8_scale_tuple(
+                                hidden_states
+                            )
                         if _dsa_needs_bf16:
                             hidden_states = (
                                 hidden_states[0],

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from enum import Enum
 from functools import lru_cache
-from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
 
 import torch
 
@@ -68,6 +68,29 @@ _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _use_aiter_gfx95 = _use_aiter and _is_gfx95_supported
 # ROCm 7.0 hipcc miscompiles gemm_a8w8_blockscale_bpreshuffle on gfx95 (#23319).
 _use_aiter_bpreshuffle_gfx95 = _use_aiter_gfx95 and get_hip_version() >= (7, 2, 0)
+
+
+def materialize_bpreshuffle_fp8_scale(scale: torch.Tensor) -> torch.Tensor:
+    """Materialize the physical scale layout consumed by gfx95 bpreshuffle GEMM."""
+    if scale.dim() != 2:
+        return scale
+    return scale.t().contiguous().t()
+
+
+def materialize_bpreshuffle_fp8_scale_tuple(value: Any) -> Any:
+    """Materialize the scale slot in FP8 ``(q_input, x_scale, ...)`` tuples."""
+    if (
+        isinstance(value, tuple)
+        and len(value) >= 2
+        and torch.is_tensor(value[0])
+        and torch.is_tensor(value[1])
+    ):
+        return (
+            value[0],
+            materialize_bpreshuffle_fp8_scale(value[1]),
+            *value[2:],
+        )
+    return value
 
 
 def use_aiter_triton_gemm_w8a8_tuned_gfx950(n: int, k: int) -> bool:
@@ -822,16 +845,21 @@ def aiter_w8a8_block_fp8_linear(
     if input_scale is not None:
         q_input = input_2d
         x_scale = input_scale
+        if _use_aiter_bpreshuffle_gfx95 and not use_triton:
+            x_scale = materialize_bpreshuffle_fp8_scale(x_scale)
         # On ROCm >= 7.2, scale is in bpreshuffle's transposed layout.
         # Triton needs a row-major view, so adjust strides only. No copy.
-        if use_triton and _use_aiter_bpreshuffle_gfx95:
+        elif use_triton and _use_aiter_bpreshuffle_gfx95:
             x_scale = torch.as_strided(x_scale, x_scale.shape, (1, x_scale.shape[0]))
     else:
+        materialize_bpreshuffle_scale = _use_aiter_bpreshuffle_gfx95 and not use_triton
         q_input, x_scale = aiter_per1x128_quant(
             input_2d,
             quant_dtype=aiter.dtypes.fp8,
-            transpose_scale=(_use_aiter_bpreshuffle_gfx95 and not use_triton),
+            transpose_scale=False,
         )
+        if materialize_bpreshuffle_scale:
+            x_scale = materialize_bpreshuffle_fp8_scale(x_scale)
 
     if use_triton:
         gemm_a8w8_blockscale_op = triton_gemm_a8w8_blockscale

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from enum import Enum
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
 
 import torch
 
@@ -75,22 +75,6 @@ def materialize_bpreshuffle_fp8_scale(scale: torch.Tensor) -> torch.Tensor:
     if scale.dim() != 2:
         return scale
     return scale.t().contiguous().t()
-
-
-def materialize_bpreshuffle_fp8_scale_tuple(value: Any) -> Any:
-    """Materialize the scale slot in FP8 ``(q_input, x_scale, ...)`` tuples."""
-    if (
-        isinstance(value, tuple)
-        and len(value) >= 2
-        and torch.is_tensor(value[0])
-        and torch.is_tensor(value[1])
-    ):
-        return (
-            value[0],
-            materialize_bpreshuffle_fp8_scale(value[1]),
-            *value[2:],
-        )
-    return value
 
 
 def use_aiter_triton_gemm_w8a8_tuned_gfx950(n: int, k: int) -> bool:
@@ -847,10 +831,6 @@ def aiter_w8a8_block_fp8_linear(
         x_scale = input_scale
         if _use_aiter_bpreshuffle_gfx95 and not use_triton:
             x_scale = materialize_bpreshuffle_fp8_scale(x_scale)
-        # On ROCm >= 7.2, scale is in bpreshuffle's transposed layout.
-        # Triton needs a row-major view, so adjust strides only. No copy.
-        elif use_triton and _use_aiter_bpreshuffle_gfx95:
-            x_scale = torch.as_strided(x_scale, x_scale.shape, (1, x_scale.shape[0]))
     else:
         materialize_bpreshuffle_scale = _use_aiter_bpreshuffle_gfx95 and not use_triton
         q_input, x_scale = aiter_per1x128_quant(

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -72,9 +72,18 @@ _use_aiter_bpreshuffle_gfx95 = _use_aiter_gfx95 and get_hip_version() >= (7, 2, 
 
 def materialize_bpreshuffle_fp8_scale(scale: torch.Tensor) -> torch.Tensor:
     """Materialize the physical scale layout consumed by gfx95 bpreshuffle GEMM."""
-    if scale.dim() != 2:
-        return scale
-    return scale.t().contiguous().t()
+    return scale.t().contiguous().t() if scale.dim() == 2 else scale
+
+
+def materialize_bpreshuffle_fp8_scale_tuple(
+    value: Tuple[torch.Tensor, ...],
+) -> Tuple[torch.Tensor, ...]:
+    """Materialize the scale slot in FP8 ``(q_input, x_scale, ...)`` tuples."""
+    return (
+        value[0],
+        materialize_bpreshuffle_fp8_scale(value[1]),
+        *value[2:],
+    )
 
 
 def use_aiter_triton_gemm_w8a8_tuned_gfx950(n: int, k: int) -> bool:
@@ -831,6 +840,10 @@ def aiter_w8a8_block_fp8_linear(
         x_scale = input_scale
         if _use_aiter_bpreshuffle_gfx95 and not use_triton:
             x_scale = materialize_bpreshuffle_fp8_scale(x_scale)
+        # On ROCm >= 7.2, scale is in bpreshuffle's transposed layout.
+        # Triton needs a row-major view, so adjust strides only. No copy.
+        elif use_triton and _use_aiter_bpreshuffle_gfx95:
+            x_scale = torch.as_strided(x_scale, x_scale.shape, (1, x_scale.shape[0]))
     else:
         materialize_bpreshuffle_scale = _use_aiter_bpreshuffle_gfx95 and not use_triton
         q_input, x_scale = aiter_per1x128_quant(

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -9,6 +9,9 @@ from sglang.srt.layers.attention.dsa.dequant_k_cache import dequantize_k_cache_p
 from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
 from sglang.srt.layers.attention.utils import concat_and_cast_mha_k_triton
 from sglang.srt.layers.communicator import get_attn_tp_context
+from sglang.srt.layers.quantization.fp8_utils import (
+    materialize_bpreshuffle_fp8_scale_tuple,
+)
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.forward_context import (
     get_attn_backend,
@@ -153,8 +156,10 @@ class DeepseekMHAForwardMixin:
                         dtype_quant=torch.float8_e4m3fn,
                         res1=None,
                         output_unquantized_inp1=True,
-                        transpose_scale=_use_aiter_bpreshuffle_gfx95,
+                        transpose_scale=False,
                     )
+                    if _use_aiter_bpreshuffle_gfx95:
+                        q_quanted = materialize_bpreshuffle_fp8_scale_tuple(q_quanted)
                     q = self.q_b_proj(q_quanted)[0].view(
                         -1, self.num_local_heads, self.qk_head_dim
                     )
@@ -195,8 +200,10 @@ class DeepseekMHAForwardMixin:
                     dtype_quant=torch.float8_e4m3fn,
                     res1=None,
                     output_unquantized_inp1=False,
-                    transpose_scale=_use_aiter_bpreshuffle_gfx95,
+                    transpose_scale=False,
                 )
+                if _use_aiter_bpreshuffle_gfx95:
+                    q = materialize_bpreshuffle_fp8_scale_tuple(q)
                 q = self.q_b_proj(q)[0].view(-1, self.num_local_heads, self.qk_head_dim)
             else:
                 q = self.q_a_layernorm(q)
@@ -225,8 +232,10 @@ class DeepseekMHAForwardMixin:
                 dtype_quant=torch.float8_e4m3fn,
                 res1=None,
                 output_unquantized_inp1=True,  # return unqaunt kv_a
-                transpose_scale=_use_aiter_bpreshuffle_gfx95,
+                transpose_scale=False,
             )
+            if _use_aiter_bpreshuffle_gfx95:
+                kv_a_quanted = materialize_bpreshuffle_fp8_scale_tuple(kv_a_quanted)
 
         else:
             kv_a = self.kv_a_layernorm(kv_a)

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -9,6 +9,9 @@ from sglang.srt.layers.attention.dsa.dequant_k_cache import dequantize_k_cache_p
 from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
 from sglang.srt.layers.attention.utils import concat_and_cast_mha_k_triton
 from sglang.srt.layers.communicator import get_attn_tp_context
+from sglang.srt.layers.quantization.fp8_utils import (
+    materialize_bpreshuffle_fp8_scale_tuple,
+)
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.forward_context import (
     get_attn_backend,
@@ -19,6 +22,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_hip,
     _is_musa,
     _is_npu,
+    _use_aiter_bpreshuffle_gfx95,
     _use_aiter_gfx95,
 )
 from sglang.srt.server_args import get_global_server_args
@@ -154,6 +158,8 @@ class DeepseekMHAForwardMixin:
                         output_unquantized_inp1=True,
                         transpose_scale=False,
                     )
+                    if _use_aiter_bpreshuffle_gfx95:
+                        q_quanted = materialize_bpreshuffle_fp8_scale_tuple(q_quanted)
                     q = self.q_b_proj(q_quanted)[0].view(
                         -1, self.num_local_heads, self.qk_head_dim
                     )
@@ -196,6 +202,8 @@ class DeepseekMHAForwardMixin:
                     output_unquantized_inp1=False,
                     transpose_scale=False,
                 )
+                if _use_aiter_bpreshuffle_gfx95:
+                    q = materialize_bpreshuffle_fp8_scale_tuple(q)
                 q = self.q_b_proj(q)[0].view(-1, self.num_local_heads, self.qk_head_dim)
             else:
                 q = self.q_a_layernorm(q)
@@ -226,6 +234,9 @@ class DeepseekMHAForwardMixin:
                 output_unquantized_inp1=True,  # return unqaunt kv_a
                 transpose_scale=False,
             )
+            if _use_aiter_bpreshuffle_gfx95:
+                kv_a_quanted = materialize_bpreshuffle_fp8_scale_tuple(kv_a_quanted)
+
         else:
             kv_a = self.kv_a_layernorm(kv_a)
 

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -9,9 +9,6 @@ from sglang.srt.layers.attention.dsa.dequant_k_cache import dequantize_k_cache_p
 from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
 from sglang.srt.layers.attention.utils import concat_and_cast_mha_k_triton
 from sglang.srt.layers.communicator import get_attn_tp_context
-from sglang.srt.layers.quantization.fp8_utils import (
-    materialize_bpreshuffle_fp8_scale_tuple,
-)
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.forward_context import (
     get_attn_backend,
@@ -22,7 +19,6 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_hip,
     _is_musa,
     _is_npu,
-    _use_aiter_bpreshuffle_gfx95,
     _use_aiter_gfx95,
 )
 from sglang.srt.server_args import get_global_server_args
@@ -158,8 +154,6 @@ class DeepseekMHAForwardMixin:
                         output_unquantized_inp1=True,
                         transpose_scale=False,
                     )
-                    if _use_aiter_bpreshuffle_gfx95:
-                        q_quanted = materialize_bpreshuffle_fp8_scale_tuple(q_quanted)
                     q = self.q_b_proj(q_quanted)[0].view(
                         -1, self.num_local_heads, self.qk_head_dim
                     )
@@ -202,8 +196,6 @@ class DeepseekMHAForwardMixin:
                     output_unquantized_inp1=False,
                     transpose_scale=False,
                 )
-                if _use_aiter_bpreshuffle_gfx95:
-                    q = materialize_bpreshuffle_fp8_scale_tuple(q)
                 q = self.q_b_proj(q)[0].view(-1, self.num_local_heads, self.qk_head_dim)
             else:
                 q = self.q_a_layernorm(q)
@@ -234,9 +226,6 @@ class DeepseekMHAForwardMixin:
                 output_unquantized_inp1=True,  # return unqaunt kv_a
                 transpose_scale=False,
             )
-            if _use_aiter_bpreshuffle_gfx95:
-                kv_a_quanted = materialize_bpreshuffle_fp8_scale_tuple(kv_a_quanted)
-
         else:
             kv_a = self.kv_a_layernorm(kv_a)
 

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -13,9 +13,6 @@ from sglang.srt.layers.quantization.fp8_kernel import (
     per_tensor_quant_mla_fp8,
     per_token_group_quant_mla_deep_gemm_masked_fp8,
 )
-from sglang.srt.layers.quantization.fp8_utils import (
-    materialize_bpreshuffle_fp8_scale_tuple,
-)
 from sglang.srt.layers.utils.cp_utils import mla_use_prefill_cp
 from sglang.srt.lora.deepseek_mla_correction import (
     apply_q_correction as apply_kv_b_lora_q_correction,
@@ -43,7 +40,6 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_hip,
     _is_musa,
     _use_aiter,
-    _use_aiter_bpreshuffle_gfx95,
     _use_aiter_gfx95,
 )
 from sglang.srt.server_args import get_global_server_args
@@ -205,11 +201,6 @@ class DeepseekMLAForwardMixin:
                                 output_unquantized_inp1=True,
                                 transpose_scale=False,
                             )
-                            if _use_aiter_bpreshuffle_gfx95:
-                                q_quanted = materialize_bpreshuffle_fp8_scale_tuple(
-                                    q_quanted
-                                )
-                                k_nope = materialize_bpreshuffle_fp8_scale_tuple(k_nope)
                             q = q_quanted
                         else:
                             q, _, k_nope, _ = fused_rms_fp8_group_quant(
@@ -225,10 +216,6 @@ class DeepseekMLAForwardMixin:
                                 output_unquantized_inp1=False,
                                 transpose_scale=False,
                             )
-                            if _use_aiter_bpreshuffle_gfx95:
-                                q = materialize_bpreshuffle_fp8_scale_tuple(q)
-                                k_nope = materialize_bpreshuffle_fp8_scale_tuple(k_nope)
-
                     elif _use_aiter:
                         q, k_nope = fused_qk_rmsnorm_bf16(
                             q,
@@ -680,10 +667,6 @@ class DeepseekMLAForwardMixin:
                         dtype_quant=torch.float8_e4m3fn,
                         transpose_scale=False,
                     )
-                    if _use_aiter_bpreshuffle_gfx95:
-                        attn_bmm_output = materialize_bpreshuffle_fp8_scale_tuple(
-                            attn_bmm_output
-                        )
                 else:
                     attn_bmm_output = _bmm_buf.flatten(1, 2)
             elif self.o_proj.weight.dtype == torch.uint8:
@@ -697,10 +680,6 @@ class DeepseekMLAForwardMixin:
                     dtype_quant=torch.float8_e4m3fn,
                     transpose_scale=False,
                 )
-                if _use_aiter_bpreshuffle_gfx95:
-                    attn_bmm_output = materialize_bpreshuffle_fp8_scale_tuple(
-                        attn_bmm_output
-                    )
             else:
                 attn_bmm_output = attn_bmm_output.transpose(0, 1).flatten(1, 2)
 

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -13,6 +13,9 @@ from sglang.srt.layers.quantization.fp8_kernel import (
     per_tensor_quant_mla_fp8,
     per_token_group_quant_mla_deep_gemm_masked_fp8,
 )
+from sglang.srt.layers.quantization.fp8_utils import (
+    materialize_bpreshuffle_fp8_scale_tuple,
+)
 from sglang.srt.layers.utils.cp_utils import mla_use_prefill_cp
 from sglang.srt.lora.deepseek_mla_correction import (
     apply_q_correction as apply_kv_b_lora_q_correction,
@@ -40,6 +43,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_hip,
     _is_musa,
     _use_aiter,
+    _use_aiter_bpreshuffle_gfx95,
     _use_aiter_gfx95,
 )
 from sglang.srt.server_args import get_global_server_args
@@ -201,6 +205,10 @@ class DeepseekMLAForwardMixin:
                                 output_unquantized_inp1=True,
                                 transpose_scale=False,
                             )
+                            if _use_aiter_bpreshuffle_gfx95:
+                                q_quanted = materialize_bpreshuffle_fp8_scale_tuple(
+                                    q_quanted
+                                )
                             q = q_quanted
                         else:
                             q, _, k_nope, _ = fused_rms_fp8_group_quant(
@@ -216,6 +224,9 @@ class DeepseekMLAForwardMixin:
                                 output_unquantized_inp1=False,
                                 transpose_scale=False,
                             )
+                            if _use_aiter_bpreshuffle_gfx95:
+                                q = materialize_bpreshuffle_fp8_scale_tuple(q)
+
                     elif _use_aiter:
                         q, k_nope = fused_qk_rmsnorm_bf16(
                             q,
@@ -667,6 +678,10 @@ class DeepseekMLAForwardMixin:
                         dtype_quant=torch.float8_e4m3fn,
                         transpose_scale=False,
                     )
+                    if _use_aiter_bpreshuffle_gfx95:
+                        attn_bmm_output = materialize_bpreshuffle_fp8_scale_tuple(
+                            attn_bmm_output
+                        )
                 else:
                     attn_bmm_output = _bmm_buf.flatten(1, 2)
             elif self.o_proj.weight.dtype == torch.uint8:
@@ -680,6 +695,10 @@ class DeepseekMLAForwardMixin:
                     dtype_quant=torch.float8_e4m3fn,
                     transpose_scale=False,
                 )
+                if _use_aiter_bpreshuffle_gfx95:
+                    attn_bmm_output = materialize_bpreshuffle_fp8_scale_tuple(
+                        attn_bmm_output
+                    )
             else:
                 attn_bmm_output = attn_bmm_output.transpose(0, 1).flatten(1, 2)
 

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -13,6 +13,9 @@ from sglang.srt.layers.quantization.fp8_kernel import (
     per_tensor_quant_mla_fp8,
     per_token_group_quant_mla_deep_gemm_masked_fp8,
 )
+from sglang.srt.layers.quantization.fp8_utils import (
+    materialize_bpreshuffle_fp8_scale_tuple,
+)
 from sglang.srt.layers.utils.cp_utils import mla_use_prefill_cp
 from sglang.srt.lora.deepseek_mla_correction import (
     apply_q_correction as apply_kv_b_lora_q_correction,
@@ -200,8 +203,13 @@ class DeepseekMLAForwardMixin:
                                 dtype_quant=torch.float8_e4m3fn,
                                 res1=None,
                                 output_unquantized_inp1=True,
-                                transpose_scale=_use_aiter_bpreshuffle_gfx95,
+                                transpose_scale=False,
                             )
+                            if _use_aiter_bpreshuffle_gfx95:
+                                q_quanted = materialize_bpreshuffle_fp8_scale_tuple(
+                                    q_quanted
+                                )
+                                k_nope = materialize_bpreshuffle_fp8_scale_tuple(k_nope)
                             q = q_quanted
                         else:
                             q, _, k_nope, _ = fused_rms_fp8_group_quant(
@@ -215,8 +223,11 @@ class DeepseekMLAForwardMixin:
                                 dtype_quant=torch.float8_e4m3fn,
                                 res1=None,
                                 output_unquantized_inp1=False,
-                                transpose_scale=_use_aiter_bpreshuffle_gfx95,
+                                transpose_scale=False,
                             )
+                            if _use_aiter_bpreshuffle_gfx95:
+                                q = materialize_bpreshuffle_fp8_scale_tuple(q)
+                                k_nope = materialize_bpreshuffle_fp8_scale_tuple(k_nope)
 
                     elif _use_aiter:
                         q, k_nope = fused_qk_rmsnorm_bf16(
@@ -667,8 +678,12 @@ class DeepseekMLAForwardMixin:
                         _bmm_buf,
                         group_size=128,
                         dtype_quant=torch.float8_e4m3fn,
-                        transpose_scale=_use_aiter_bpreshuffle_gfx95,
+                        transpose_scale=False,
                     )
+                    if _use_aiter_bpreshuffle_gfx95:
+                        attn_bmm_output = materialize_bpreshuffle_fp8_scale_tuple(
+                            attn_bmm_output
+                        )
                 else:
                     attn_bmm_output = _bmm_buf.flatten(1, 2)
             elif self.o_proj.weight.dtype == torch.uint8:
@@ -680,8 +695,12 @@ class DeepseekMLAForwardMixin:
                     attn_bmm_output,
                     group_size=128,
                     dtype_quant=torch.float8_e4m3fn,
-                    transpose_scale=_use_aiter_bpreshuffle_gfx95,
+                    transpose_scale=False,
                 )
+                if _use_aiter_bpreshuffle_gfx95:
+                    attn_bmm_output = materialize_bpreshuffle_fp8_scale_tuple(
+                        attn_bmm_output
+                    )
             else:
                 attn_bmm_output = attn_bmm_output.transpose(0, 1).flatten(1, 2)
 

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -106,9 +106,6 @@ from sglang.srt.layers.quantization.fp8 import Fp8Config
 from sglang.srt.layers.quantization.fp8_kernel import (
     create_per_token_group_quant_fp8_output_scale,
 )
-from sglang.srt.layers.quantization.fp8_utils import (
-    materialize_bpreshuffle_fp8_scale,
-)
 from sglang.srt.layers.quantization.mxfp4_flashinfer_trtllm_moe import (
     maybe_fuse_routed_scale_and_shared_add,
 )
@@ -162,7 +159,6 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_npu,
     _is_xpu,
     _use_aiter,
-    _use_aiter_bpreshuffle_gfx95,
     _use_aiter_gfx95,
 )
 from sglang.srt.runtime_context import get_parallel
@@ -379,8 +375,6 @@ class DeepseekV2MLP(nn.Module):
                     dtype_quant=dtypes.fp8,
                     transpose_scale=False,
                 )
-                if _use_aiter_bpreshuffle_gfx95:
-                    x_scale = materialize_bpreshuffle_fp8_scale(x_scale)
                 x = (x_fp8, x_scale)
             else:
                 x = fused_clamp_act_mul(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -106,6 +106,9 @@ from sglang.srt.layers.quantization.fp8 import Fp8Config
 from sglang.srt.layers.quantization.fp8_kernel import (
     create_per_token_group_quant_fp8_output_scale,
 )
+from sglang.srt.layers.quantization.fp8_utils import (
+    materialize_bpreshuffle_fp8_scale,
+)
 from sglang.srt.layers.quantization.mxfp4_flashinfer_trtllm_moe import (
     maybe_fuse_routed_scale_and_shared_add,
 )
@@ -374,8 +377,10 @@ class DeepseekV2MLP(nn.Module):
                     swiglu_limit=self.swiglu_limit,
                     activation="silu",
                     dtype_quant=dtypes.fp8,
-                    transpose_scale=_use_aiter_bpreshuffle_gfx95,
+                    transpose_scale=False,
                 )
+                if _use_aiter_bpreshuffle_gfx95:
+                    x_scale = materialize_bpreshuffle_fp8_scale(x_scale)
                 x = (x_fp8, x_scale)
             else:
                 x = fused_clamp_act_mul(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -106,6 +106,9 @@ from sglang.srt.layers.quantization.fp8 import Fp8Config
 from sglang.srt.layers.quantization.fp8_kernel import (
     create_per_token_group_quant_fp8_output_scale,
 )
+from sglang.srt.layers.quantization.fp8_utils import (
+    materialize_bpreshuffle_fp8_scale,
+)
 from sglang.srt.layers.quantization.mxfp4_flashinfer_trtllm_moe import (
     maybe_fuse_routed_scale_and_shared_add,
 )
@@ -159,6 +162,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _is_npu,
     _is_xpu,
     _use_aiter,
+    _use_aiter_bpreshuffle_gfx95,
     _use_aiter_gfx95,
 )
 from sglang.srt.runtime_context import get_parallel
@@ -375,6 +379,8 @@ class DeepseekV2MLP(nn.Module):
                     dtype_quant=dtypes.fp8,
                     transpose_scale=False,
                 )
+                if _use_aiter_bpreshuffle_gfx95:
+                    x_scale = materialize_bpreshuffle_fp8_scale(x_scale)
                 x = (x_fp8, x_scale)
             else:
                 x = fused_clamp_act_mul(

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -71,6 +71,9 @@ from sglang.srt.layers.mhc import mhc_fused_post_pre, npu_hc_pre
 from sglang.srt.layers.moe import get_moe_a2a_backend, should_use_dp_reduce_scatterv
 from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
 from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
+from sglang.srt.layers.quantization.fp8_utils import (
+    materialize_bpreshuffle_fp8_scale_tuple,
+)
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.utils.cp_utils import (
@@ -176,8 +179,10 @@ def _fused_rmsnorm_fp8_quant(hidden_states, weight, eps):
         dtype_quant=torch.float8_e4m3fn,
         res1=None,
         output_unquantized_inp1=True,
-        transpose_scale=_use_aiter_bpreshuffle_gfx95,
+        transpose_scale=False,
     )
+    if _use_aiter_bpreshuffle_gfx95:
+        x_quant = materialize_bpreshuffle_fp8_scale_tuple(x_quant)
     return x_quant, x_bf16
 
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -71,9 +71,6 @@ from sglang.srt.layers.mhc import mhc_fused_post_pre, npu_hc_pre
 from sglang.srt.layers.moe import get_moe_a2a_backend, should_use_dp_reduce_scatterv
 from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
 from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
-from sglang.srt.layers.quantization.fp8_utils import (
-    materialize_bpreshuffle_fp8_scale_tuple,
-)
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.utils.cp_utils import (
@@ -179,10 +176,8 @@ def _fused_rmsnorm_fp8_quant(hidden_states, weight, eps):
         dtype_quant=torch.float8_e4m3fn,
         res1=None,
         output_unquantized_inp1=True,
-        transpose_scale=False,
+        transpose_scale=_use_aiter_bpreshuffle_gfx95,
     )
-    if _use_aiter_bpreshuffle_gfx95:
-        x_quant = materialize_bpreshuffle_fp8_scale_tuple(x_quant)
     return x_quant, x_bf16
 
 

--- a/test/registered/unit/layers/test_fp8_bpreshuffle_scale.py
+++ b/test/registered/unit/layers/test_fp8_bpreshuffle_scale.py
@@ -4,7 +4,6 @@ import torch
 
 from sglang.srt.layers.quantization.fp8_utils import (
     materialize_bpreshuffle_fp8_scale,
-    materialize_bpreshuffle_fp8_scale_tuple,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -13,6 +12,17 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 class TestBpreshuffleScaleMaterialization(CustomTestCase):
+    def _dequant_with_logical_scale(self, q_input, scale):
+        m, n = q_input.shape
+        ng = scale.shape[1]
+        group = n // ng
+        return (
+            q_input.to(torch.float32)
+            .view(m, ng, group)
+            .mul(scale.to(torch.float32).unsqueeze(-1))
+            .view(m, n)
+        )
+
     def test_materializes_transposed_physical_storage(self):
         scale = torch.arange(12, dtype=torch.float32).reshape(3, 4)
 
@@ -32,19 +42,31 @@ class TestBpreshuffleScaleMaterialization(CustomTestCase):
         self.assertTrue(torch.equal(rematerialized, scale))
         self.assertEqual(rematerialized.stride(), materialized.stride())
 
-    def test_tuple_helper_keeps_extra_tuple_payload(self):
+    def test_materialization_preserves_logical_scale_dequantization(self):
         q_input = torch.ones((3, 8), dtype=torch.float32)
         scale = torch.arange(12, dtype=torch.float32).reshape(3, 4)
-        bf16_side = torch.ones((3, 8), dtype=torch.bfloat16)
+        materialized = materialize_bpreshuffle_fp8_scale(scale)
 
-        q_out, scale_out, bf16_out = materialize_bpreshuffle_fp8_scale_tuple(
-            (q_input, scale, bf16_side)
+        # Simulates a row-major tensor whose underlying values were written in
+        # bpreshuffle/transposed physical order. This is the layout that is unsafe
+        # for generic consumers that index scale[m, k_block] logically.
+        shuffled_storage_row_major = scale.t().contiguous().view_as(scale)
+
+        expected = self._dequant_with_logical_scale(q_input, scale)
+
+        self.assertTrue(
+            torch.equal(
+                self._dequant_with_logical_scale(q_input, materialized), expected
+            )
         )
-
-        self.assertIs(q_out, q_input)
-        self.assertIs(bf16_out, bf16_side)
-        self.assertTrue(torch.equal(scale_out, scale))
-        self.assertEqual(scale_out.stride(), (1, scale.shape[0]))
+        self.assertFalse(
+            torch.equal(
+                self._dequant_with_logical_scale(
+                    q_input, shuffled_storage_row_major
+                ),
+                expected,
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/test_fp8_bpreshuffle_scale.py
+++ b/test/registered/unit/layers/test_fp8_bpreshuffle_scale.py
@@ -1,0 +1,51 @@
+import unittest
+
+import torch
+
+from sglang.srt.layers.quantization.fp8_utils import (
+    materialize_bpreshuffle_fp8_scale,
+    materialize_bpreshuffle_fp8_scale_tuple,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestBpreshuffleScaleMaterialization(CustomTestCase):
+    def test_materializes_transposed_physical_storage(self):
+        scale = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+
+        materialized = materialize_bpreshuffle_fp8_scale(scale)
+
+        self.assertTrue(torch.equal(materialized, scale))
+        self.assertEqual(materialized.shape, scale.shape)
+        self.assertEqual(materialized.stride(), (1, scale.shape[0]))
+        self.assertTrue(materialized.t().is_contiguous())
+
+    def test_materialization_is_idempotent_for_bpreshuffle_layout(self):
+        scale = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        materialized = materialize_bpreshuffle_fp8_scale(scale)
+
+        rematerialized = materialize_bpreshuffle_fp8_scale(materialized)
+
+        self.assertTrue(torch.equal(rematerialized, scale))
+        self.assertEqual(rematerialized.stride(), materialized.stride())
+
+    def test_tuple_helper_keeps_extra_tuple_payload(self):
+        q_input = torch.ones((3, 8), dtype=torch.float32)
+        scale = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        bf16_side = torch.ones((3, 8), dtype=torch.bfloat16)
+
+        q_out, scale_out, bf16_out = materialize_bpreshuffle_fp8_scale_tuple(
+            (q_input, scale, bf16_side)
+        )
+
+        self.assertIs(q_out, q_input)
+        self.assertIs(bf16_out, bf16_side)
+        self.assertTrue(torch.equal(scale_out, scale))
+        self.assertEqual(scale_out.stride(), (1, scale.shape[0]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/test_fp8_bpreshuffle_scale.py
+++ b/test/registered/unit/layers/test_fp8_bpreshuffle_scale.py
@@ -4,6 +4,7 @@ import torch
 
 from sglang.srt.layers.quantization.fp8_utils import (
     materialize_bpreshuffle_fp8_scale,
+    materialize_bpreshuffle_fp8_scale_tuple,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -12,17 +13,6 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 class TestBpreshuffleScaleMaterialization(CustomTestCase):
-    def _dequant_with_logical_scale(self, q_input, scale):
-        m, n = q_input.shape
-        ng = scale.shape[1]
-        group = n // ng
-        return (
-            q_input.to(torch.float32)
-            .view(m, ng, group)
-            .mul(scale.to(torch.float32).unsqueeze(-1))
-            .view(m, n)
-        )
-
     def test_materializes_transposed_physical_storage(self):
         scale = torch.arange(12, dtype=torch.float32).reshape(3, 4)
 
@@ -42,31 +32,19 @@ class TestBpreshuffleScaleMaterialization(CustomTestCase):
         self.assertTrue(torch.equal(rematerialized, scale))
         self.assertEqual(rematerialized.stride(), materialized.stride())
 
-    def test_materialization_preserves_logical_scale_dequantization(self):
+    def test_tuple_helper_keeps_extra_tuple_payload(self):
         q_input = torch.ones((3, 8), dtype=torch.float32)
         scale = torch.arange(12, dtype=torch.float32).reshape(3, 4)
-        materialized = materialize_bpreshuffle_fp8_scale(scale)
+        bf16_side = torch.ones((3, 8), dtype=torch.bfloat16)
 
-        # Simulates a row-major tensor whose underlying values were written in
-        # bpreshuffle/transposed physical order. This is the layout that is unsafe
-        # for generic consumers that index scale[m, k_block] logically.
-        shuffled_storage_row_major = scale.t().contiguous().view_as(scale)
-
-        expected = self._dequant_with_logical_scale(q_input, scale)
-
-        self.assertTrue(
-            torch.equal(
-                self._dequant_with_logical_scale(q_input, materialized), expected
-            )
+        q_out, scale_out, bf16_out = materialize_bpreshuffle_fp8_scale_tuple(
+            (q_input, scale, bf16_side)
         )
-        self.assertFalse(
-            torch.equal(
-                self._dequant_with_logical_scale(
-                    q_input, shuffled_storage_row_major
-                ),
-                expected,
-            )
-        )
+
+        self.assertIs(q_out, q_input)
+        self.assertIs(bf16_out, bf16_side)
+        self.assertTrue(torch.equal(scale_out, scale))
+        self.assertEqual(scale_out.stride(), (1, scale.shape[0]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

GLM-5.2-FP8 on gfx950/ROCm 7.2 routes untuned block-FP8 linear shapes through the AITER/CK bpreshuffle path. CK PR ROCm/rocm-libraries#8639 fixes the underlying bpreshuffle GEMM kernel, but the SGLang model path can still feed activation scales in the wrong physical storage layout for gfx95 bpreshuffle consumers.

This PR fixes the SGLang producer/consumer scale-layout contract without changing the logical FP8 GEMM math.

## Modifications

- Add helpers to materialize FP8 activation scales into the physical layout consumed by gfx95 bpreshuffle GEMM.
- Make FP8 quant producers emit normal logical scale values with `transpose_scale=False`.
- Materialize only the scale slot of `(q_input, x_scale, ...)` tuples before gfx95 bpreshuffle FP8 linear consumers.
- Apply the fix at shared GLM/DeepSeek-common FP8 linear boundaries:
  - communicator RMSNorm+FP8 quant handoff
  - MHA/MLA q/kv/o_proj handoffs
  - DeepSeekV2 fused MLP down-proj handoff
- Add a registered CPU unit test for scale value preservation, stride/materialization, idempotence, and tuple payload preservation.

## Accuracy Tests

GLM-5.2-FP8, TP4 on 4xMI350, GSM8K 200Q / 5-shot:

- CK PR ROCm/rocm-libraries#8639 without scale materialization: 0/82 (aborted after decisive failure).
- CK PR ROCm/rocm-libraries#8639 + scale materialization + `SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1`: 192/200, accuracy 0.96.
- CK PR ROCm/rocm-libraries#8639 + scale materialization + `SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=0`: 186/200, accuracy 0.93.
- bpreshuffle-off: 184/200, accuracy 0.92.

DeepSeek-V4 FP8 TP8 on 8xMI350 GSM8K 200Q / 5-shot:
- cookbook: 197/200
- CK PR ROCm/rocm-libraries#8639: 198/200
- CK PR ROCm/rocm-libraries#8639 + scale materialization: 196/200

So this PR does not add DSv4-specific hooks. DSv4 cookbook accuracy did not require this fix, but the shared gfx95 bpreshuffle FP8 tuple boundary is corrected for routes that do consume it.

## Speed Tests and Profiling

Short TP4, GLM-5.2-FP8 prompts:

- materialized route: tool-call prompt avg 3.02s, factual prompt avg 1.45s
- bpreshuffle-off: tool-call prompt avg 3.49s, factual prompt avg 1.71s

No materialization slowdown was observed.

## Checklist

- [x] Ran `pre-commit run --all-files` successfully in the SGLang ROCm image.
- [x] Added registered unit test under `test/registered/unit/layers/`.
- [x] Ran targeted unit test: 3 passed.
- [x] Ran accuracy validation for GLM-5.2-FP8 GSM8K and tool-call cases.
- [x] Ran speed smoke.